### PR TITLE
fix: resolve ion-input focus issue in edit mode

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -157,7 +157,7 @@ const { ensureValidSession } = useAuth()
 const { currencySymbol, currencyCode, loadSavedCurrency, formatAmount } = useCurrency()
 const showAmountInput = ref(false)
 const currentAmount = ref('')
-const amountInput = ref<HTMLInputElement>()
+const amountInput = ref()
 
 const todayLogged = computed(() => {
   const today = new Date().toISOString().split('T')[0]
@@ -284,7 +284,7 @@ const cancelAmount = () => {
 const editTodayAmount = () => {
   currentAmount.value = todayAmount.value
   showAmountInput.value = true
-  setTimeout(() => amountInput.value?.focus(), 100)
+  setTimeout(() => amountInput.value?.$el.setFocus(), 100)
 }
 
 const onAmountBlur = () => {


### PR DESCRIPTION
- Update editTodayAmount to use Ionic input's setFocus() method
- Remove HTMLInputElement type constraint for amountInput ref
- Fix focus functionality when editing today's spending amount

🤖 Generated with [Claude Code](https://claude.ai/code)