### PR TITLE
fix: make LineChart component responsive to parent width

### DIFF
--- a/src/components/LineChart.vue
+++ b/src/components/LineChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="line-chart">
+  <div ref="chartContainer" class="line-chart">
     <svg 
       ref="chartSvg"
       :width="chartWidth" 
@@ -104,7 +104,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useCurrency } from '@/composables/useCurrency'
 
 interface Props {
@@ -115,8 +115,9 @@ const props = defineProps<Props>()
 const { formatAmount } = useCurrency()
 
 const chartSvg = ref<SVGElement>()
-const chartWidth = 350
-const chartHeight = 200
+const chartContainer = ref<HTMLElement>()
+const chartWidth = ref(350)
+const chartHeight = ref(200)
 const padding = { top: 20, right: 20, bottom: 40, left: 50 }
 
 const tooltip = ref({
@@ -160,8 +161,8 @@ const maxAmount = computed(() => {
 })
 
 const dataPoints = computed(() => {
-  const plotWidth = chartWidth - padding.left - padding.right
-  const plotHeight = chartHeight - padding.top - padding.bottom
+  const plotWidth = chartWidth.value - padding.left - padding.right
+  const plotHeight = chartHeight.value - padding.top - padding.bottom
   
   return chartData.value.map((item, index) => {
     const x = padding.left + (index / (chartData.value.length - 1)) * plotWidth
@@ -196,7 +197,7 @@ const linePath = computed(() => {
 
 const horizontalGridLines = computed(() => {
   const lines = []
-  const plotHeight = chartHeight - padding.top - padding.bottom
+  const plotHeight = chartHeight.value - padding.top - padding.bottom
   const steps = 4
   
   for (let i = 0; i <= steps; i++) {
@@ -209,7 +210,7 @@ const horizontalGridLines = computed(() => {
 
 const verticalGridLines = computed(() => {
   const lines = []
-  const plotWidth = chartWidth - padding.left - padding.right
+  const plotWidth = chartWidth.value - padding.left - padding.right
   const step = 7 // Show grid every 7 days
   
   for (let i = 0; i < chartData.value.length; i += step) {
@@ -223,7 +224,7 @@ const verticalGridLines = computed(() => {
 const yAxisLabels = computed(() => {
   const labels = []
   const steps = 4
-  const plotHeight = chartHeight - padding.top - padding.bottom
+  const plotHeight = chartHeight.value - padding.top - padding.bottom
   
   for (let i = 0; i <= steps; i++) {
     const value = (maxAmount.value / steps) * (steps - i)
@@ -241,7 +242,7 @@ const yAxisLabels = computed(() => {
 
 const xAxisLabels = computed(() => {
   const labels = []
-  const plotWidth = chartWidth - padding.left - padding.right
+  const plotWidth = chartWidth.value - padding.left - padding.right
   const step = 7 // Show label every 7 days
   
   for (let i = 0; i < chartData.value.length; i += step) {
@@ -293,20 +294,45 @@ const onMouseMove = (event: MouseEvent) => {
 const hideTooltip = () => {
   tooltip.value.show = false
 }
+
+// Responsive functionality
+const updateSize = () => {
+  if (chartContainer.value) {
+    const containerWidth = chartContainer.value.clientWidth
+    chartWidth.value = Math.max(containerWidth, 300) // Minimum width of 300px
+    chartHeight.value = Math.min(containerWidth * 0.6, 250) // Maintain aspect ratio, max height 250px
+  }
+}
+
+const resizeObserver = new ResizeObserver(() => {
+  updateSize()
+})
+
+onMounted(() => {
+  updateSize()
+  if (chartContainer.value) {
+    resizeObserver.observe(chartContainer.value)
+  }
+})
+
+onUnmounted(() => {
+  resizeObserver.disconnect()
+})
 </script>
 
 <style scoped>
 .line-chart {
   position: relative;
   width: 100%;
-  display: flex;
-  justify-content: center;
+  display: block;
 }
 
 .chart-svg {
   background: white;
   border-radius: 8px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  height: auto;
 }
 
 .line-path {
@@ -354,10 +380,4 @@ const hideTooltip = () => {
   font-weight: 600;
 }
 
-@media (max-width: 480px) {
-  .chart-svg {
-    width: 100%;
-    height: auto;
-  }
-}
 </style>


### PR DESCRIPTION
## Summary
- Fix LineChart component not expanding to fill parent container width
- Implement responsive design that adapts to any container size

## Problem
The LineChart component had a fixed width of 350px, preventing it from utilizing the full available space in its parent container, especially on larger screens or when used within responsive layouts.

## Solution
- **Reactive Dimensions**: Converted fixed `chartWidth` and `chartHeight` to reactive refs
- **ResizeObserver**: Added container size monitoring for real-time responsiveness  
- **Dynamic Sizing**: Chart now adapts to container width with configurable constraints
- **Aspect Ratio**: Maintains proper proportions (width * 0.6 for height, max 250px)
- **Minimum Width**: Ensures readability with 300px minimum width
- **Updated Computed Properties**: All calculations now use reactive dimensions

## Technical Changes
- Added `chartContainer` ref and ResizeObserver for size monitoring
- Updated all computed properties to use `chartWidth.value` and `chartHeight.value`
- Improved CSS for better responsive behavior
- Removed redundant mobile-specific styles

## Benefits
- Chart now fills available width on all screen sizes
- Better data visualization on larger displays
- Maintains readability on smaller screens
- Automatic adaptation to container size changes

🤖 Generated with [Claude Code](https://claude.ai/code)