### PR TITLE
fix: add category field to TypeScript database type definitions

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,7 +3,7 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)
 
 export type Database = {
   public: {
@@ -14,6 +14,7 @@ export type Database = {
           user_id: string
           amount: number
           currency: string
+          category: string | null
           date: string
           created_at: string
         }
@@ -22,6 +23,7 @@ export type Database = {
           user_id: string
           amount: number
           currency: string
+          category?: string | null
           date: string
           created_at?: string
         }
@@ -30,6 +32,7 @@ export type Database = {
           user_id?: string
           amount?: number
           currency?: string
+          category?: string | null
           date?: string
           created_at?: string
         }
@@ -43,7 +46,7 @@ export interface SpendingEntry {
   user_id: string
   amount: number
   currency: string
-  category: string
+  category?: string | null
   date: string
   created_at: string
 }


### PR DESCRIPTION
## Summary
- Add missing `category` field to Database type definitions in supabase.ts
- Update SpendingEntry interface to make category optional for backward compatibility
- Add generic typing to supabase client for better type safety

## Changes Made
- **Database.Row**: Added `category: string | null`
- **Database.Insert**: Added `category?: string | null`
- **Database.Update**: Added `category?: string | null`
- **SpendingEntry**: Updated to `category?: string | null`
- **Supabase Client**: Added generic `Database` type

## Why This Fix Was Needed
The category functionality was working in the UI but had TypeScript type mismatches:
- Frontend code was using category field but Database types didn't include it
- This could lead to runtime errors and loss of type safety
- Category field is now properly typed as nullable to handle legacy entries

## Testing
- ✅ TypeScript compilation passes (`npm run typecheck`)
- ✅ End-to-end category functionality verified
- ✅ Both predefined and custom categories work correctly
- ✅ Category data persists to database properly

## Impact
- **Type Safety**: Full IntelliSense and compile-time checking for category operations
- **Backward Compatibility**: Handles entries created before category feature
- **Developer Experience**: Better autocomplete and error detection

🤖 Generated with [Claude Code](https://claude.ai/code)