### PR TITLE
feat: add inputmode attribute to amount input for better mobile UX

### DIFF
--- a/src/components/SpendingDialog.vue
+++ b/src/components/SpendingDialog.vue
@@ -51,6 +51,7 @@
           ref="amountInput"
           v-model="amount"
           type="number"
+          inputmode="decimal"
           placeholder="0.00"
           step="0.01"
           min="0"


### PR DESCRIPTION
## Summary
- Add `inputmode="decimal"` to amount input in SpendingDialog.vue
- Optimizes mobile keyboard to show numeric keypad with decimal point
- Improves user experience when entering spending amounts on mobile devices

## Test plan
- [ ] Verify the amount input shows decimal keypad on mobile devices
- [ ] Confirm TypeScript build passes without errors
- [ ] Test that spending amounts can still be entered correctly

Fixes #33

🤖 Generated with [Claude Code](https://claude.ai/code)